### PR TITLE
Update GDAL from source for R docker image

### DIFF
--- a/docker_R/Dockerfile
+++ b/docker_R/Dockerfile
@@ -20,17 +20,18 @@ WORKDIR /home/rstudio/
 
 #default GDAL is kinda old, we need >= 2.3 for ID field in geojson
 #uninstall the included GDAL first
-RUN sudo apt-get remove libgdal-dev \
+RUN sudo apt-get remove --assume-yes libgdal-dev \
   && wget http://download.osgeo.org/gdal/2.4.2/gdal-2.4.2.tar.gz \
   && tar -xzvf gdal-2.4.2.tar.gz \
   && cd gdal-2.4.2 \
   && ./configure --prefix=/usr \
   && make && make install \
+  && cd ../ \
   && rm gdal-2.4.2.tar.gz && rm -rf gdal-2.4.2
 
 RUN install2.r --error \
-	lwgeom \	
- 	geojsonio
+	sf \
+	lwgeom 
 
 RUN mkdir -p wbeep-processing &&\
     chown rstudio wbeep-processing

--- a/docker_R/Dockerfile
+++ b/docker_R/Dockerfile
@@ -18,6 +18,16 @@ RUN /usr/bin/wget -O /usr/lib/ssl/certs/DOIRootCA.crt http://sslhelp.doi.net/doc
 
 WORKDIR /home/rstudio/
 
+#default GDAL is kinda old, we need >= 2.3 for ID field in geojson
+#uninstall the included GDAL first
+RUN sudo apt-get remove libgdal-dev \
+  && wget http://download.osgeo.org/gdal/2.4.2/gdal-2.4.2.tar.gz \
+  && tar -xzvf gdal-2.4.2.tar.gz \
+  && cd gdal-2.4.2 \
+  && ./configure --prefix=/usr \
+  && make && make install \
+  && rm gdal-2.4.2.tar.gz && rm -rf gdal-2.4.2
+
 RUN install2.r --error \
 	lwgeom \	
  	geojsonio


### PR DESCRIPTION
I had assumed that the GDAL included in the R geospatial docker image would be reasonably new, but I guess it's just whatever comes with Ubuntu, and the current binary for Bionic Beaver is too old.  We need >= 2.2.3 for the geojson ID field.