### PR TITLE
Keep HRU ID around in GeoJSON properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,8 @@ cache/*
 tile*
 *.png
 *.gz
+*.dbf
+*.prj
+*.shp
+*.shx
+*.zip

--- a/jenkins/hru_R_Jenkinsfile
+++ b/jenkins/hru_R_Jenkinsfile
@@ -22,7 +22,7 @@ pipeline {
       }
       steps {
         sh 'Rscript -e "source(\'src/process_hru_shapes.R\')"'
-        sh 'ogr2ogr -f GeoJSON hrus.geojson -lco COORDINATE_PRECISION=5 -lco ID_FIELD=hru_id_nat hru_reduced_valid.shp'
+        sh 'ogr2ogr -f GeoJSON hrus.geojson -lco COORDINATE_PRECISION=5 -lco ID_FIELD=hru_id_2 hru_reduced_valid.shp'
       }
     }
     stage('push to S3') {

--- a/src/process_hru_shapes.R
+++ b/src/process_hru_shapes.R
@@ -7,7 +7,7 @@ gfdb <- "cache/GF_nat_reg.gdb"
 hru_reduced <- read_sf(gfdb, "nhru")  %>% 
   dplyr::select(Shape, hru_id_nat) %>% 
   st_transform(crs = proj_string) %>% 
-  dplyr::mutate(hrud_id_2 = hru_id_nat) #need ID in two places in final output
+  dplyr::mutate(hru_id_2 = hru_id_nat) #need ID in two places in final output
 
 #parallelize validation
 library(parallel)

--- a/src/process_hru_shapes.R
+++ b/src/process_hru_shapes.R
@@ -6,7 +6,8 @@ proj_string <- 4326
 gfdb <- "cache/GF_nat_reg.gdb"
 hru_reduced <- read_sf(gfdb, "nhru")  %>% 
   dplyr::select(Shape, hru_id_nat) %>% 
-  st_transform(crs = proj_string)
+  st_transform(crs = proj_string) %>% 
+  dplyr::mutate(hrud_id_2 = hru_id_nat) #need ID in two places in final output
 
 #parallelize validation
 library(parallel)


### PR DESCRIPTION
It seems that the ID_FIELD option in `ogr2ogr` moves that field from the `properties` tier of the JSON.  This PR adds an identical ID column in the R step, and uses that for the `ID_FIELD`, so the original one is still preserved in the `properties` tier.