### PR TITLE
Passing tier and tag between jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # wbeep-processing
 the processing behind the wbeep viz
+
+## Building a release
+
+There are four Jenkins jobs chained together, in this order:
+
+`HRU to GeoJSON -> Tippecanoe tile creation -> model output processing -> tile join`
+
+To build a release, cut the release in this repository with an appropriate vx.x.x tag.  Go to the `HRU to GeoJSON` job, and start it with the appropriate tier and tag.  The tag list should populate automatically.  The tier and tag will be passed along to the downstream jobs.  
+
+For non-release changes to test that only affect downstream jobs, you can start the appropriate job and will pass the parameters downstream the same way.  
+
+The `HRU to GeoJSON -> Tippecanoe tile creation` part of the pipeline can run parallel to the model output processing job in terms of dependencies; the pipeline is linear for now in the interest of making the Jenkins jobs simpler.  

--- a/jenkins/hru_R_Jenkinsfile
+++ b/jenkins/hru_R_Jenkinsfile
@@ -21,7 +21,7 @@ pipeline {
                           extensions: [],
                           gitTool: 'Default',
                           submoduleCfg: [],
-                          userRemoteConfigs: [[url: 'https://github.com/wdwatkins/wbeep-processing']]
+                          userRemoteConfigs: [[url: 'https://github.com/usgs-makerspace/wbeep-processing']]
                         ])
         sh 'aws s3 sync s3://prod-owi-resources/resources/Application/wbeep/${TIER}/hru_shape/GF_nat_reg.gdb cache/GF_nat_reg.gdb'
       }

--- a/jenkins/hru_R_Jenkinsfile
+++ b/jenkins/hru_R_Jenkinsfile
@@ -4,13 +4,25 @@ pipeline {
             label 'node:slave'
         }
     }
-    // try to trigger Jenkins
+    parameters {
+        gitParameter name: 'BRANCH_TAG',
+                     type: 'PT_BRANCH_TAG',
+                     defaultValue: 'master'
+        choice(choices: ['test', 'qa', 'prod'], description: 'Tier to deploy tiles to', name: 'TIER')
+  }
   stages {
     stage('Checkout repo and pull from S3') {
       agent any 
       steps {
         sh 'wget -O DOIRootCA2.cer http://sslhelp.doi.net/docs/DOIRootCA2.cer'
-        git 'https://github.com/usgs-makerspace/wbeep-processing'
+        checkout([$class: 'GitSCM',
+                          branches: [[name: "${params.BRANCH_TAG}"]],
+                          doGenerateSubmoduleConfigurations: false,
+                          extensions: [],
+                          gitTool: 'Default',
+                          submoduleCfg: [],
+                          userRemoteConfigs: [[url: 'https://github.com/wdwatkins/wbeep-processing']]
+                        ])
         sh 'aws s3 sync s3://prod-owi-resources/resources/Application/wbeep/${TIER}/hru_shape/GF_nat_reg.gdb cache/GF_nat_reg.gdb'
       }
     }
@@ -30,6 +42,14 @@ pipeline {
       agent any
       steps { 
         sh 'aws s3 cp hrus.geojson s3://prod-owi-resources/resources/Application/wbeep/${TIER}/hru_shape/hrus.geojson --content-type "application/json"'
+      }
+    }
+    stage('build downstream job') {
+      steps { 
+        sh "echo ${params.BRANCH_TAG}"
+        build job: 'tippecanoe build tileset', 
+              parameters: [string(name: 'TIER', value: String.valueOf(TIER)),
+              string(name: 'BRANCH_TAG', value: "${params.BRANCH_TAG}")]
       }
     }
   }

--- a/jenkins/model_output_processing_Jenkinsfile
+++ b/jenkins/model_output_processing_Jenkinsfile
@@ -50,8 +50,8 @@ pipeline {
     stage('build downstream job') {
       steps { 
         build job: 'tippecanoe_tile_join', 
-              parameters: [[$class: 'StringParameterValue', name: 'TIER', value: String.valueOf(TIER),
-              $class: 'GitParameterValue', name: BRANCH_TAG, value: String.valueOf(BRANCH_TAG)]]
+              parameters: [string(name: 'TIER', value: '${params.TIER}'),
+              string(name: BRANCH_TAG, value: '{params.BRANCH_TAG})]
       }
     }
   }

--- a/jenkins/model_output_processing_Jenkinsfile
+++ b/jenkins/model_output_processing_Jenkinsfile
@@ -51,7 +51,7 @@ pipeline {
       steps { 
         build job: 'tippecanoe_tile_join', 
               parameters: [[$class: 'StringParameterValue', name: 'TIER', value: String.valueOf(TIER),
-              $class: 'GitParameterValue', name: BRANCH_TAG, value: Git.valueOf(BRANCH_TAG)]]
+              $class: 'GitParameterValue', name: BRANCH_TAG, value: String.valueOf(BRANCH_TAG)]]
       }
     }
   }

--- a/jenkins/model_output_processing_Jenkinsfile
+++ b/jenkins/model_output_processing_Jenkinsfile
@@ -52,7 +52,7 @@ pipeline {
         sh "echo ${params.BRANCH_TAG}"
         build job: 'tippecanoe_tile_join', 
               parameters: [string(name: 'TIER', value: String.valueOf(TIER)),
-              string(name: 'BRANCH_TAG', value: '${params.BRANCH_TAG}')]
+              string(name: 'BRANCH_TAG', value: "${params.BRANCH_TAG}")]
       }
     }
   }

--- a/jenkins/model_output_processing_Jenkinsfile
+++ b/jenkins/model_output_processing_Jenkinsfile
@@ -51,7 +51,7 @@ pipeline {
       steps { 
         build job: 'tippecanoe_tile_join', 
               parameters: [string(name: 'TIER', value: String.valueOf(TIER)),
-              string(name: BRANCH_TAG, value: "${params.BRANCH_TAG}")]
+              string(name: BRANCH_TAG, value: ${BRANCH_TAG})]
       }
     }
   }

--- a/jenkins/model_output_processing_Jenkinsfile
+++ b/jenkins/model_output_processing_Jenkinsfile
@@ -8,7 +8,7 @@ pipeline {
         gitParameter name: 'BRANCH_TAG',
                      type: 'PT_BRANCH_TAG',
                      defaultValue: 'master'
-        choice(choices: ['test', 'prod'], description: 'Tier to deploy tiles to', name: 'TIER')
+        choice(choices: ['test', 'qa', 'prod'], description: 'Tier to deploy tiles to', name: 'TIER')
   }
   stages {
     stage('Checkout repo and pull model output from S3') {

--- a/jenkins/model_output_processing_Jenkinsfile
+++ b/jenkins/model_output_processing_Jenkinsfile
@@ -14,7 +14,7 @@ pipeline {
     stage('Checkout repo and pull model output from S3') {
       steps {
         sh 'wget -O DOIRootCA2.cer http://sslhelp.doi.net/docs/DOIRootCA2.cer'
-        git_vars = checkout([$class: 'GitSCM',
+        final git_vars = checkout([$class: 'GitSCM',
                           branches: [[name: "${params.BRANCH_TAG}"]],
                           doGenerateSubmoduleConfigurations: false,
                           extensions: [],

--- a/jenkins/model_output_processing_Jenkinsfile
+++ b/jenkins/model_output_processing_Jenkinsfile
@@ -51,7 +51,7 @@ pipeline {
       steps { 
         build job: 'tippecanoe_tile_join', 
               parameters: [string(name: 'TIER', value: String.valueOf(TIER)),
-              string(name: 'BRANCH_TAG', value: '${BRANCH_TAG}')]
+              string(name: 'BRANCH_TAG', value: gitParameter.valueOf(BRANCH_TAG))]
       }
     }
   }

--- a/jenkins/model_output_processing_Jenkinsfile
+++ b/jenkins/model_output_processing_Jenkinsfile
@@ -4,18 +4,30 @@ pipeline {
             label 'node:slave'
         }
     }
-/*  parameters {
-    string(name: DATE, defaultValue: $(date -d "yesterday 13:00" '+%Y-%m-%d') )
-  } */
+  parameters {
+        gitParameter name: 'BRANCH_TAG',
+                     type: 'PT_BRANCH_TAG',
+                     defaultValue: 'master'
+        choice(choices: ['test', 'prod'], description: 'Tier to deploy tiles to', name: 'TIER')
+  }
   stages {
     stage('Checkout repo and pull model output from S3') {
       steps {
         sh 'wget -O DOIRootCA2.cer http://sslhelp.doi.net/docs/DOIRootCA2.cer'
-        git 'https://github.com/usgs-makerspace/wbeep-processing'
+         checkout([$class: 'GitSCM',
+                          branches: [[name: "${params.BRANCH_TAG}"]],
+                          doGenerateSubmoduleConfigurations: false,
+                          extensions: [],
+                          gitTool: 'Default',
+                          submoduleCfg: [],
+                          userRemoteConfigs: [[url: 'https://github.com/wdwatkins/wbeep-processing']]
+                        ])
+        //git 'https://github.com/usgs-makerspace/wbeep-processing'
         // This will fail if the new file isn't there
         // Note that the Jenkins is on UTC!
         // May need to actually use yesterday's date depending on what time of day this runs
-        sh 'DATE=$(date -d "yesterday 13:00" "+%Y_%m_%d"); wget https://owi-common-resources.s3-us-west-2.amazonaws.com/resources/application/nhm/output/data/climate_${DATE}.nc'
+        //sh 'DATE=$(date -d "yesterday 13:00" "+%Y_%m_%d"); wget https://owi-common-resources.s3-us-west-2.amazonaws.com/resources/application/nhm/output/data/climate_${DATE}.nc'
+        sh 'DATE=2019_08_22; wget https://owi-common-resources.s3-us-west-2.amazonaws.com/resources/application/nhm/output/data/climate_${DATE}.nc'
       }
     }
     stage('convert model output to csv for tile-join') {
@@ -27,7 +39,7 @@ pipeline {
         } 
       }
       steps {
-        sh 'DATE=\$(date -d "yesterday 13:00" "+%Y_%m_%d"); Rscript src/process_model_output.R ${DATE}'
+        sh 'DATE=2019_08_22; Rscript src/process_model_output.R ${DATE}'
       }
     }
     stage('push to S3') {
@@ -37,7 +49,9 @@ pipeline {
     }
     stage('build downstream job') {
       steps { 
-        build job: 'tippecanoe_tile_join', parameters: [[$class: 'StringParameterValue', name: 'TIER', value: TIER]]
+        build job: 'tippecanoe_tile_join', 
+              parameters: [[$class: 'StringParameterValue', name: 'TIER', value: TIER,
+              $class: 'GitParameterValue', name: BRANCH_TAG, value: BRANCH_TAG]]
       }
     }
   }

--- a/jenkins/model_output_processing_Jenkinsfile
+++ b/jenkins/model_output_processing_Jenkinsfile
@@ -51,7 +51,7 @@ pipeline {
       steps { 
         build job: 'tippecanoe_tile_join', 
               parameters: [string(name: 'TIER', value: String.valueOf(TIER)),
-              string(name: BRANCH_TAG, value: String.valueOf(BRANCH_TAG))]
+              string(name: BRANCH_TAG, value: "${params.BRANCH_TAG}")]
       }
     }
   }

--- a/jenkins/model_output_processing_Jenkinsfile
+++ b/jenkins/model_output_processing_Jenkinsfile
@@ -50,8 +50,8 @@ pipeline {
     stage('build downstream job') {
       steps { 
         build job: 'tippecanoe_tile_join', 
-              parameters: [[$class: 'StringParameterValue', name: 'TIER', value: TIER,
-              $class: 'GitParameterValue', name: BRANCH_TAG, value: BRANCH_TAG]]
+              parameters: [[$class: 'StringParameterValue', name: 'TIER', value: ${TIER},
+              $class: 'GitParameterValue', name: BRANCH_TAG, value: ${BRANCH_TAG]}]
       }
     }
   }

--- a/jenkins/model_output_processing_Jenkinsfile
+++ b/jenkins/model_output_processing_Jenkinsfile
@@ -50,7 +50,7 @@ pipeline {
     stage('build downstream job') {
       steps { 
         build job: 'tippecanoe_tile_join', 
-              parameters: [[$class: 'StringParameterValue', name: 'TIER', value: String.valueOf(TIER)},
+              parameters: [[$class: 'StringParameterValue', name: 'TIER', value: String.valueOf(TIER),
               $class: 'GitParameterValue', name: BRANCH_TAG, value: Git.valueOf(BRANCH_TAG)]]
       }
     }

--- a/jenkins/model_output_processing_Jenkinsfile
+++ b/jenkins/model_output_processing_Jenkinsfile
@@ -14,7 +14,7 @@ pipeline {
     stage('Checkout repo and pull model output from S3') {
       steps {
         sh 'wget -O DOIRootCA2.cer http://sslhelp.doi.net/docs/DOIRootCA2.cer'
-         checkout([$class: 'GitSCM',
+        git_vars = checkout([$class: 'GitSCM',
                           branches: [[name: "${params.BRANCH_TAG}"]],
                           doGenerateSubmoduleConfigurations: false,
                           extensions: [],
@@ -49,9 +49,10 @@ pipeline {
     }
     stage('build downstream job') {
       steps { 
+        sh 'print git_vars' 
         build job: 'tippecanoe_tile_join', 
               parameters: [string(name: 'TIER', value: String.valueOf(TIER)),
-              string(name: 'BRANCH_TAG', value: gitParameter.valueOf(BRANCH_TAG))]
+              string(name: 'BRANCH_TAG', value: '${git_vars.branches}')]
       }
     }
   }

--- a/jenkins/model_output_processing_Jenkinsfile
+++ b/jenkins/model_output_processing_Jenkinsfile
@@ -20,7 +20,7 @@ pipeline {
                           extensions: [],
                           gitTool: 'Default',
                           submoduleCfg: [],
-                          userRemoteConfigs: [[url: 'https://github.com/wdwatkins/wbeep-processing']]
+                          userRemoteConfigs: [[url: 'https://github.com/usgs-makerspace/wbeep-processing']]
                         ])
         //git 'https://github.com/usgs-makerspace/wbeep-processing'
         // This will fail if the new file isn't there

--- a/jenkins/model_output_processing_Jenkinsfile
+++ b/jenkins/model_output_processing_Jenkinsfile
@@ -49,7 +49,7 @@ pipeline {
     }
     stage('build downstream job') {
       steps { 
-        sh 'echo ${params.BRANCH_TAG}'
+        sh "echo ${params.BRANCH_TAG}"
         build job: 'tippecanoe_tile_join', 
               parameters: [string(name: 'TIER', value: String.valueOf(TIER)),
               string(name: 'BRANCH_TAG', value: '${params.BRANCH_TAG}')]

--- a/jenkins/model_output_processing_Jenkinsfile
+++ b/jenkins/model_output_processing_Jenkinsfile
@@ -14,7 +14,7 @@ pipeline {
     stage('Checkout repo and pull model output from S3') {
       steps {
         sh 'wget -O DOIRootCA2.cer http://sslhelp.doi.net/docs/DOIRootCA2.cer'
-        final git_vars = checkout([$class: 'GitSCM',
+        def git_vars = checkout([$class: 'GitSCM',
                           branches: [[name: "${params.BRANCH_TAG}"]],
                           doGenerateSubmoduleConfigurations: false,
                           extensions: [],

--- a/jenkins/model_output_processing_Jenkinsfile
+++ b/jenkins/model_output_processing_Jenkinsfile
@@ -51,7 +51,7 @@ pipeline {
       steps { 
         build job: 'tippecanoe_tile_join', 
               parameters: [string(name: 'TIER', value: '${params.TIER}'),
-              string(name: BRANCH_TAG, value: '{params.BRANCH_TAG})]
+              string(name: BRANCH_TAG, value: '{params.BRANCH_TAG}')]
       }
     }
   }

--- a/jenkins/model_output_processing_Jenkinsfile
+++ b/jenkins/model_output_processing_Jenkinsfile
@@ -51,7 +51,7 @@ pipeline {
       steps { 
         build job: 'tippecanoe_tile_join', 
               parameters: [[$class: 'StringParameterValue', name: 'TIER', value: ${TIER},
-              $class: 'GitParameterValue', name: BRANCH_TAG, value: ${BRANCH_TAG]}]
+              $class: 'GitParameterValue', name: BRANCH_TAG, value: ${BRANCH_TAG}]]
       }
     }
   }

--- a/jenkins/model_output_processing_Jenkinsfile
+++ b/jenkins/model_output_processing_Jenkinsfile
@@ -50,8 +50,8 @@ pipeline {
     stage('build downstream job') {
       steps { 
         build job: 'tippecanoe_tile_join', 
-              parameters: [string(name: 'TIER', value: '${params.TIER}'),
-              string(name: BRANCH_TAG, value: '{params.BRANCH_TAG}')]
+              parameters: [string(name: 'TIER', value: String.valueOf(TIER)),
+              string(name: BRANCH_TAG, value: String.valueOf(BRANCH_TAG))]
       }
     }
   }

--- a/jenkins/model_output_processing_Jenkinsfile
+++ b/jenkins/model_output_processing_Jenkinsfile
@@ -51,7 +51,7 @@ pipeline {
       steps { 
         build job: 'tippecanoe_tile_join', 
               parameters: [string(name: 'TIER', value: String.valueOf(TIER)),
-              string(name: BRANCH_TAG, value: ${BRANCH_TAG})]
+              string(name: 'BRANCH_TAG', value: ${BRANCH_TAG})]
       }
     }
   }

--- a/jenkins/model_output_processing_Jenkinsfile
+++ b/jenkins/model_output_processing_Jenkinsfile
@@ -51,7 +51,7 @@ pipeline {
       steps { 
         build job: 'tippecanoe_tile_join', 
               parameters: [string(name: 'TIER', value: String.valueOf(TIER)),
-              string(name: 'BRANCH_TAG', value: ${BRANCH_TAG})]
+              string(name: 'BRANCH_TAG', value: '${BRANCH_TAG}')]
       }
     }
   }

--- a/jenkins/model_output_processing_Jenkinsfile
+++ b/jenkins/model_output_processing_Jenkinsfile
@@ -14,7 +14,7 @@ pipeline {
     stage('Checkout repo and pull model output from S3') {
       steps {
         sh 'wget -O DOIRootCA2.cer http://sslhelp.doi.net/docs/DOIRootCA2.cer'
-        def git_vars = checkout([$class: 'GitSCM',
+        checkout([$class: 'GitSCM',
                           branches: [[name: "${params.BRANCH_TAG}"]],
                           doGenerateSubmoduleConfigurations: false,
                           extensions: [],
@@ -52,7 +52,7 @@ pipeline {
         sh 'print git_vars' 
         build job: 'tippecanoe_tile_join', 
               parameters: [string(name: 'TIER', value: String.valueOf(TIER)),
-              string(name: 'BRANCH_TAG', value: '${git_vars.branches}')]
+              string(name: 'BRANCH_TAG', value: '${params.BRANCH_TAG}')]
       }
     }
   }

--- a/jenkins/model_output_processing_Jenkinsfile
+++ b/jenkins/model_output_processing_Jenkinsfile
@@ -50,8 +50,8 @@ pipeline {
     stage('build downstream job') {
       steps { 
         build job: 'tippecanoe_tile_join', 
-              parameters: [[$class: 'StringParameterValue', name: 'TIER', value: ${TIER},
-              $class: 'GitParameterValue', name: BRANCH_TAG, value: ${BRANCH_TAG}]]
+              parameters: [[$class: 'StringParameterValue', name: 'TIER', value: String.valueOf(TIER)},
+              $class: 'GitParameterValue', name: BRANCH_TAG, value: Git.valueOf(BRANCH_TAG)]]
       }
     }
   }

--- a/jenkins/model_output_processing_Jenkinsfile
+++ b/jenkins/model_output_processing_Jenkinsfile
@@ -49,7 +49,7 @@ pipeline {
     }
     stage('build downstream job') {
       steps { 
-        sh 'print git_vars' 
+        sh 'echo ${params.BRANCH_TAG}'
         build job: 'tippecanoe_tile_join', 
               parameters: [string(name: 'TIER', value: String.valueOf(TIER)),
               string(name: 'BRANCH_TAG', value: '${params.BRANCH_TAG}')]

--- a/jenkins/tippecanoe_create_tiles_Jenkinsfile
+++ b/jenkins/tippecanoe_create_tiles_Jenkinsfile
@@ -30,7 +30,6 @@ pipeline {
         docker {
           image 'code.chs.usgs.gov:5001/wma/iidd/wbeep-data-processing:tippecanoe-latest'
           alwaysPull true
-          reuseNode true
         } 
       }
       steps {

--- a/jenkins/tippecanoe_create_tiles_Jenkinsfile
+++ b/jenkins/tippecanoe_create_tiles_Jenkinsfile
@@ -4,11 +4,24 @@ pipeline {
             label 'node:slave'
         }
     }
+  parameters {
+        gitParameter name: 'BRANCH_TAG',
+                     type: 'PT_BRANCH_TAG',
+                     defaultValue: 'master'
+        choice(choices: ['test', 'qa', 'prod'], description: 'Tier to deploy tiles to', name: 'TIER')
+  }
   stages {
     stage('Checkout repo and pull from S3') {
       steps {
         sh 'wget -O DOIRootCA2.cer http://sslhelp.doi.net/docs/DOIRootCA2.cer'
-        git "https://github.com/usgs-makerspace/wbeep-processing"
+         checkout([$class: 'GitSCM',
+                          branches: [[name: "${params.BRANCH_TAG}"]],
+                          doGenerateSubmoduleConfigurations: false,
+                          extensions: [],
+                          gitTool: 'Default',
+                          submoduleCfg: [],
+                          userRemoteConfigs: [[url: 'https://github.com/wdwatkins/wbeep-processing']]
+                        ])
         sh 'aws s3 sync s3://prod-owi-resources/resources/Application/wbeep/${TIER}/hru_shape . --exclude "*" --include "hrus.geojson"'
       }
     }
@@ -27,6 +40,14 @@ pipeline {
     stage('push to S3') {
       steps { 
         sh 'aws s3 sync tile_dir_simple5 s3://prod-owi-resources/resources/Application/wbeep/${TIER}/hru_shape/tile_dir_simple5'
+      }
+    }
+    stage('build downstream job') {
+      steps { 
+        sh "echo ${params.BRANCH_TAG}"
+        build job: 'process_model_output', 
+              parameters: [string(name: 'TIER', value: String.valueOf(TIER)),
+              string(name: 'BRANCH_TAG', value: "${params.BRANCH_TAG}")]
       }
     }
   }

--- a/jenkins/tippecanoe_create_tiles_Jenkinsfile
+++ b/jenkins/tippecanoe_create_tiles_Jenkinsfile
@@ -20,7 +20,7 @@ pipeline {
                           extensions: [],
                           gitTool: 'Default',
                           submoduleCfg: [],
-                          userRemoteConfigs: [[url: 'https://github.com/wdwatkins/wbeep-processing']]
+                          userRemoteConfigs: [[url: 'https://github.com/usgs-makerspace/wbeep-processing']]
                         ])
         sh 'aws s3 sync s3://prod-owi-resources/resources/Application/wbeep/${TIER}/hru_shape . --exclude "*" --include "hrus.geojson"'
       }

--- a/jenkins/tippecanoe_tile_join_Jenkinsfile
+++ b/jenkins/tippecanoe_tile_join_Jenkinsfile
@@ -48,7 +48,6 @@ pipeline {
     }
     stage('push to S3') {
       steps { 
-         //TODO: match URL with TIER variable
           script {
                     if ("${TIER}" == "prod") {
                         targetDomain = "s3://wbeep-prod-website"
@@ -62,7 +61,6 @@ pipeline {
                         targetDomain = "s3://wbeep-test-website"
                     }   
             }
-        sh "echo ${targetDomain}; echo ${TIER}"
         sh "aws s3 sync tiles ${targetDomain}/tiles --content-encoding gzip --content-type application/x-protobuf"
       }
     }

--- a/jenkins/tippecanoe_tile_join_Jenkinsfile
+++ b/jenkins/tippecanoe_tile_join_Jenkinsfile
@@ -49,7 +49,8 @@ pipeline {
     stage('push to S3') {
       steps { 
          //TODO: match URL with TIER variable
-          if ("${params.TIER}" == "prod") {
+          script {
+                    if ("${params.TIER}" == "prod") {
                         targetDomain = "s3://wbeep-prod-website"
                     }   
                     else if ("${params.TIER}" == "qa") {
@@ -60,7 +61,7 @@ pipeline {
                     else {
                         targetDomain = "s3://wbeep-test-website"
                     }   
-
+            }
         sh 'aws s3 sync tiles "${targetDomain}"/tiles --content-encoding "gzip" --content-type application/x-protobuf'
       }
     }

--- a/jenkins/tippecanoe_tile_join_Jenkinsfile
+++ b/jenkins/tippecanoe_tile_join_Jenkinsfile
@@ -19,7 +19,7 @@ pipeline {
     stage('Checkout repo and pull from S3') {
       steps {
         sh 'wget -O DOIRootCA2.cer http://sslhelp.doi.net/docs/DOIRootCA2.cer'
-        sh 'printf ${params.BRANCH_TAG}\n; print ${params.TIER}\n'
+        //sh 'printf ${params.BRANCH_TAG}\n; print ${params.TIER}\n'
         checkout([$class: 'GitSCM',
                           branches: [[name: "${params.BRANCH_TAG}"]],
                           doGenerateSubmoduleConfigurations: false,

--- a/jenkins/tippecanoe_tile_join_Jenkinsfile
+++ b/jenkins/tippecanoe_tile_join_Jenkinsfile
@@ -63,7 +63,7 @@ pipeline {
                     }   
             }
         sh "echo ${targetDomain}; echo ${TIER}"
-        sh 'aws s3 sync tiles ${targetDomain}/tiles --content-encoding "gzip" --content-type application/x-protobuf'
+        sh "aws s3 sync tiles ${targetDomain}/tiles --content-encoding gzip --content-type application/x-protobuf"
       }
     }
   }

--- a/jenkins/tippecanoe_tile_join_Jenkinsfile
+++ b/jenkins/tippecanoe_tile_join_Jenkinsfile
@@ -48,7 +48,7 @@ pipeline {
     }
     stage('push to S3') {
       steps { 
-         /TODO: match URL with TIER variable
+         //TODO: match URL with TIER variable
         sh 'aws s3 sync tiles s3://wbeep-test-website/tiles --content-encoding "gzip" --content-type application/x-protobuf'
       }
     }

--- a/jenkins/tippecanoe_tile_join_Jenkinsfile
+++ b/jenkins/tippecanoe_tile_join_Jenkinsfile
@@ -19,6 +19,7 @@ pipeline {
     stage('Checkout repo and pull from S3') {
       steps {
         sh 'wget -O DOIRootCA2.cer http://sslhelp.doi.net/docs/DOIRootCA2.cer'
+        sh 'printf ${params.BRANCH_TAG}\n; print ${params.TIER}\n'
         checkout([$class: 'GitSCM',
                           branches: [[name: "${params.BRANCH_TAG}"]],
                           doGenerateSubmoduleConfigurations: false,
@@ -47,6 +48,7 @@ pipeline {
     }
     stage('push to S3') {
       steps { 
+         #TODO: match URL with TIER variable
         sh 'aws s3 sync tiles s3://wbeep-test-website/tiles --content-encoding "gzip" --content-type application/x-protobuf'
       }
     }

--- a/jenkins/tippecanoe_tile_join_Jenkinsfile
+++ b/jenkins/tippecanoe_tile_join_Jenkinsfile
@@ -50,10 +50,11 @@ pipeline {
       steps { 
          //TODO: match URL with TIER variable
           script {
-                    if ("${params.TIER}" == "prod") {
+                    echo "${TIER}"
+                    if ("${TIER}" == "prod") {
                         targetDomain = "s3://wbeep-prod-website"
                     }   
-                    else if ("${params.TIER}" == "qa") {
+                    else if ("${TIER}" == "qa") {
                         //only here for testing propagating variable
                         // we aren't using tiles hosted here
                         targetDomain = "s3://wbeep-qa-website"
@@ -62,7 +63,7 @@ pipeline {
                         targetDomain = "s3://wbeep-test-website"
                     }   
             }
-        sh 'echo ${targetDomain}'
+        sh "echo ${targetDomain}""
         sh 'aws s3 sync tiles ${targetDomain}/tiles --content-encoding "gzip" --content-type application/x-protobuf'
       }
     }

--- a/jenkins/tippecanoe_tile_join_Jenkinsfile
+++ b/jenkins/tippecanoe_tile_join_Jenkinsfile
@@ -18,8 +18,8 @@ pipeline {
 	}
     stage('Checkout repo and pull from S3') {
       steps {
+        sh "echo ${params.BRANCH_TAG}"
         sh 'wget -O DOIRootCA2.cer http://sslhelp.doi.net/docs/DOIRootCA2.cer'
-        //sh 'printf ${params.BRANCH_TAG}\n; print ${params.TIER}\n'
         checkout([$class: 'GitSCM',
                           branches: [[name: "${params.BRANCH_TAG}"]],
                           doGenerateSubmoduleConfigurations: false,

--- a/jenkins/tippecanoe_tile_join_Jenkinsfile
+++ b/jenkins/tippecanoe_tile_join_Jenkinsfile
@@ -26,7 +26,7 @@ pipeline {
                           extensions: [],
                           gitTool: 'Default',
                           submoduleCfg: [],
-                          userRemoteConfigs: [[url: 'https://github.com/wdwatkins/wbeep-processing']]
+                          userRemoteConfigs: [[url: 'https://github.com/usgs-makerspace/wbeep-processing']]
                         ])
         sh "mkdir ${WORKSPACE}/tile_dir_simple5"
         sh "mkdir ${WORKSPACE}/tiles"

--- a/jenkins/tippecanoe_tile_join_Jenkinsfile
+++ b/jenkins/tippecanoe_tile_join_Jenkinsfile
@@ -50,7 +50,6 @@ pipeline {
       steps { 
          //TODO: match URL with TIER variable
           script {
-                    echo "${TIER}"
                     if ("${TIER}" == "prod") {
                         targetDomain = "s3://wbeep-prod-website"
                     }   
@@ -63,7 +62,7 @@ pipeline {
                         targetDomain = "s3://wbeep-test-website"
                     }   
             }
-        sh "echo ${targetDomain}""
+        sh "echo ${targetDomain}; echo ${TIER}""
         sh 'aws s3 sync tiles ${targetDomain}/tiles --content-encoding "gzip" --content-type application/x-protobuf'
       }
     }

--- a/jenkins/tippecanoe_tile_join_Jenkinsfile
+++ b/jenkins/tippecanoe_tile_join_Jenkinsfile
@@ -62,7 +62,8 @@ pipeline {
                         targetDomain = "s3://wbeep-test-website"
                     }   
             }
-        sh 'aws s3 sync tiles "${targetDomain}"/tiles --content-encoding "gzip" --content-type application/x-protobuf'
+        sh 'echo ${targetDomain}'
+        sh 'aws s3 sync tiles ${targetDomain}/tiles --content-encoding "gzip" --content-type application/x-protobuf'
       }
     }
   }

--- a/jenkins/tippecanoe_tile_join_Jenkinsfile
+++ b/jenkins/tippecanoe_tile_join_Jenkinsfile
@@ -4,6 +4,12 @@ pipeline {
             label 'node:slave'
         }
     }
+  parameters {
+        gitParameter name: 'BRANCH_TAG',
+                     type: 'PT_BRANCH_TAG',
+                     defaultValue: 'master'
+        choice(choices: ['test', 'qa', 'prod'], description: 'Tier to deploy tiles to', name: 'TIER')
+  }
   stages {
 	stage('Clean Workspace') {
 	  steps{
@@ -13,7 +19,14 @@ pipeline {
     stage('Checkout repo and pull from S3') {
       steps {
         sh 'wget -O DOIRootCA2.cer http://sslhelp.doi.net/docs/DOIRootCA2.cer'
-        git "https://github.com/usgs-makerspace/wbeep-processing"
+        checkout([$class: 'GitSCM',
+                          branches: [[name: "${params.BRANCH_TAG}"]],
+                          doGenerateSubmoduleConfigurations: false,
+                          extensions: [],
+                          gitTool: 'Default',
+                          submoduleCfg: [],
+                          userRemoteConfigs: [[url: 'https://github.com/wdwatkins/wbeep-processing']]
+                        ])
         sh "mkdir ${WORKSPACE}/tile_dir_simple5"
         sh "mkdir ${WORKSPACE}/tiles"
         sh 'aws s3 sync s3://prod-owi-resources/resources/Application/wbeep/${TIER}/ . --exclude "*" --include "model_output_categorized.csv"'

--- a/jenkins/tippecanoe_tile_join_Jenkinsfile
+++ b/jenkins/tippecanoe_tile_join_Jenkinsfile
@@ -62,7 +62,7 @@ pipeline {
                         targetDomain = "s3://wbeep-test-website"
                     }   
             }
-        sh "echo ${targetDomain}; echo ${TIER}""
+        sh "echo ${targetDomain}; echo ${TIER}"
         sh 'aws s3 sync tiles ${targetDomain}/tiles --content-encoding "gzip" --content-type application/x-protobuf'
       }
     }

--- a/jenkins/tippecanoe_tile_join_Jenkinsfile
+++ b/jenkins/tippecanoe_tile_join_Jenkinsfile
@@ -18,7 +18,7 @@ pipeline {
 	}
     stage('Checkout repo and pull from S3') {
       steps {
-        sh "echo ${params.BRANCH_TAG}"
+        sh 'env'
         sh 'wget -O DOIRootCA2.cer http://sslhelp.doi.net/docs/DOIRootCA2.cer'
         checkout([$class: 'GitSCM',
                           branches: [[name: "${params.BRANCH_TAG}"]],

--- a/jenkins/tippecanoe_tile_join_Jenkinsfile
+++ b/jenkins/tippecanoe_tile_join_Jenkinsfile
@@ -26,7 +26,7 @@ pipeline {
                           extensions: [],
                           gitTool: 'Default',
                           submoduleCfg: [],
-                          userRemoteConfigs: [[url: 'https://github.com/usgs-makerspace/wbeep-processing']]
+                          userRemoteConfigs: [[url: 'https://github.com/wdwatkins/wbeep-processing']]
                         ])
         sh "mkdir ${WORKSPACE}/tile_dir_simple5"
         sh "mkdir ${WORKSPACE}/tiles"
@@ -49,7 +49,19 @@ pipeline {
     stage('push to S3') {
       steps { 
          //TODO: match URL with TIER variable
-        sh 'aws s3 sync tiles s3://wbeep-test-website/tiles --content-encoding "gzip" --content-type application/x-protobuf'
+          if ("${params.TIER}" == "prod") {
+                        targetDomain = "s3://wbeep-prod-website"
+                    }   
+                    else if ("${params.TIER}" == "qa") {
+                        //only here for testing propagating variable
+                        // we aren't using tiles hosted here
+                        targetDomain = "s3://wbeep-qa-website"
+                    } 
+                    else {
+                        targetDomain = "s3://wbeep-test-website"
+                    }   
+
+        sh 'aws s3 sync tiles "${targetDomain}"/tiles --content-encoding "gzip" --content-type application/x-protobuf'
       }
     }
   }

--- a/jenkins/tippecanoe_tile_join_Jenkinsfile
+++ b/jenkins/tippecanoe_tile_join_Jenkinsfile
@@ -48,7 +48,7 @@ pipeline {
     }
     stage('push to S3') {
       steps { 
-         #TODO: match URL with TIER variable
+         /TODO: match URL with TIER variable
         sh 'aws s3 sync tiles s3://wbeep-test-website/tiles --content-encoding "gzip" --content-type application/x-protobuf'
       }
     }


### PR DESCRIPTION
Fixes https://github.com/usgs-makerspace/makerspace-sandbox/issues/142

This PR allows us to cut a release in the processing repo, and then kick off the HRU to Geojson job for the appropriate tier and tag.  The tier and tag will then be passed along to all the downstream jobs.

I chained the jobs together in this order:

HRU to GeoJSON -> Tippecanoe tile creation -> model output processing -> tile join

The idea here is that the later jobs will be run more frequently, so we can kick them off without recreating the tiles, which takes a long time.  