### PR TITLE
make sure hruid is not saved in scientific notation

### DIFF
--- a/src/process_quantiles.R
+++ b/src/process_quantiles.R
@@ -40,8 +40,8 @@ task_id_to_hru_seq <- function(task_id, n_hrus_per_task = 1000) {
 # Identify task id from yeti environment & convert to HRU ids ----
 task_id <- as.numeric(Sys.getenv('SLURM_ARRAY_TASK_ID', 'NA'))
 hru_seq <- task_id_to_hru_seq(task_id)
-hru_start <- head(hru_seq, 1)
-hru_end <- tail(hru_seq, 1)
+hru_start <- sprintf("%.0f", head(hru_seq, 1)) # prevents hruid from being in scientific notation as character
+hru_end <- sprintf("%.0f", tail(hru_seq, 1))
 
 message(sprintf("Started this task at %s", Sys.time()))
 

--- a/src/sum_total_storage.R
+++ b/src/sum_total_storage.R
@@ -70,14 +70,17 @@ for(g in 1:n_groups) {
   hruid_end <- hruid_start + (n_hrus_per_group-1) # which hru to end with
   hruid_end <- ifelse(hruid_end > n_hrus, yes = n_hrus, no = hruid_end)
   
-  hru_group_fn <- sprintf("grouped_total_storage/total_storage_data_%s_to_%s.feather", hruid_start, hruid_end)
+  hruid_start_char <- sprintf("%.0f", hruid_start) # will stop anything that has scientific notation
+  hruid_end_char <- sprintf("%.0f", hruid_end)
+  
+  hru_group_fn <- sprintf("grouped_total_storage/total_storage_data_%s_to_%s.feather", hruid_start_char, hruid_end_char)
   
   if(file.exists(hru_group_fn)) {
-    message(sprintf("Already completed %s to %s, skipping ...", hruid_start, hruid_end))
+    message(sprintf("Already completed %s to %s, skipping ...", hruid_start_char, hruid_end_char))
     next
   }
   
-  message(sprintf("... subsetting large data for %s to %s ...", hruid_start, hruid_end))
+  message(sprintf("... subsetting large data for %s to %s ...", hruid_start_char, hruid_end_char))
   hru_group_data <- vars_data[hruid_start:hruid_end,] # subset rows to just HRUs in this group
   
   # Keep only complete years of data


### PR DESCRIPTION
There was an issue with 1000 HRUs not having data because the `total_storage_data_from_X_to_X.feather` file was saved as `total_storage_data_from_99001_to_1e+5.feather` when it should have been `total_storage_data_from_99001_to_100000.feather`. This caused the `process_quantiles.R` step to not be able to find the correct file and consider the data missing. After this fix, there is still one HRU that has all missing quantiles: 104388. Unclear why at this point.