### PR TITLE
Drop unused data during tile join

### DIFF
--- a/jenkins/tippecanoe_tile_join_Jenkinsfile
+++ b/jenkins/tippecanoe_tile_join_Jenkinsfile
@@ -46,7 +46,7 @@ pipeline {
         } 
       }
       steps {
-        sh 'tile-join -pk --output-to-directory tiles -c model_output_categorized.csv tile_dir_simple5 --force' 
+        sh 'tile-join -pk --output-to-directory tiles -x DOY -x total_storage_today -x 0% -x 5% -x 10% -x 15% -x 20% -x 25% -x 30% -x 35% -x 40% -x 45% -x 50% -x 55% -x 60% -x 65% -x 70% -x 75% -x 80% -x 85% -x 90% -x 95% -x 100% -c model_output_categorized.csv tile_dir_simple5 --force' 
       }
     }
     stage('push to S3') {


### PR DESCRIPTION
reduces total size on disk for tiles from 590mb to 240mb