### PR TITLE
Add beta to tier choice parameter

### DIFF
--- a/jenkins/model_output_processing_Jenkinsfile
+++ b/jenkins/model_output_processing_Jenkinsfile
@@ -8,7 +8,7 @@ pipeline {
         gitParameter name: 'BRANCH_TAG',
                      type: 'PT_BRANCH_TAG',
                      defaultValue: 'master'
-        choice(choices: ['test', 'qa', 'prod'], description: 'Tier to deploy tiles to', name: 'TIER')
+        choice(choices: ['test', 'qa', 'beta', 'prod'], description: 'Tier to deploy tiles to', name: 'TIER')
   }
   stages {
     stage('Clean Workspace') {


### PR DESCRIPTION
since bumping into CORS issues with the way we are configuring some things in the vue app, aaron asked me to create a /date file on every tier, so I'm expanding the nightly runs to all the tiers. we may need to reconsider our test>test qa/beta/prod>prod configuration. everything is being hard coded into the wbeep-viz and its causing us issues.