### PR TITLE
stop code if assertions not met for processing model output on `source()`

### DIFF
--- a/src/process_model_output.R
+++ b/src/process_model_output.R
@@ -1,20 +1,20 @@
+# Code for total storage daily build
+
 library(ncdf4)
 library(dplyr)
 
 args <- commandArgs(trailingOnly=TRUE)
-today <- args[1]
-
-#### Code for total storage daily build
-#This section is code for what I think will replace the precip code when the percentile code is complete.
-# test for now b/c of the data we have
-#today <- "2019-07-31"
+# today <- args[1] #today <- "2019-07-31"
+source("src/validate_oNHM_daily_output.R") # load code to test model data
+source("src/validate_total_storage_categorized.R") # load code to test output of this categorization
 
 # Combine nc files for each var
 vars <- c("soil_moist_tot", "hru_intcpstor", "pkwater_equiv",
           "hru_impervstor", "gwres_stor", "dprst_stor_hru")
 
 var_data_list <- lapply(vars, function(var) {
-  nc <- nc_open(sprintf("%s_%s.nc", today, var))
+  fn <- sprintf("%s_%s.nc", today, var)
+  nc <- nc_open(fn)
   time <- ncvar_get(nc, varid = "time")
   hruids <- ncvar_get(nc, varid = "hruid")
 
@@ -26,6 +26,11 @@ var_data_list <- lapply(vars, function(var) {
   today_dim <- which(time_fixed == today)
   today_data_nc <- ncvar_get(nc, var, start = c(1,today_dim), count = c(-1, 1))
 
+  # Run tests before returning any data
+  message(sprintf("Started tests for %s", var))
+  validate_oNHM_daily_output(var, fn, today, today_data_nc, hruids, time, time_fixed)
+  message(sprintf("Completed tests for %s", var))
+  
   today_var_data <- data.frame(
     hruid = as.numeric(hruids),
     var_values = today_data_nc,
@@ -98,5 +103,9 @@ values_categorized <- total_storage_data %>%
                                      labels = percentile_categories,
                                      `0%`, `10%`, `25%`, `75%`, `90%`, `100%`)) %>%
   rename(hru_id_nat = hruid)
+
+message("Started tests for validating categorized output")
+validate_total_storage_categorized(values_categorized)
+message("Completed tests for validating categorized output")
 
 readr::write_csv(values_categorized, "model_output_categorized.csv")

--- a/src/process_model_output.R
+++ b/src/process_model_output.R
@@ -4,7 +4,8 @@ library(ncdf4)
 library(dplyr)
 
 args <- commandArgs(trailingOnly=TRUE)
-# today <- args[1] #today <- "2019-07-31"
+today <- args[1] #today <- "2019-07-31"
+
 source("src/validate_oNHM_daily_output.R") # load code to test model data
 source("src/validate_total_storage_categorized.R") # load code to test output of this categorization
 

--- a/src/validate_oNHM_daily_output.R
+++ b/src/validate_oNHM_daily_output.R
@@ -1,0 +1,42 @@
+library(assertthat)
+library(ncmeta)
+
+validate_oNHM_daily_output <- function(var, fn, test_date, data_nc, hruids, time, time_fixed, n_hrus = 109951) {
+  
+  ##### Test: NetCDF dimensions and variables are as expected #####
+  
+  # Get a bit more detailed metadata
+  meta_info <- nc_meta(fn)
+  atts_var_i <- which(meta_info$attribute$variable == var)
+  atts_units_i <- which(meta_info$attribute$name == "units")
+  var_unit_i <- atts_units_i[atts_units_i %in% atts_var_i]
+  
+  assert_that(meta_info$dimension$name[1] == "hruid")
+  assert_that(meta_info$dimension$name[2] == "time")
+  assert_that(meta_info$dimension$length[1] == n_hrus) # Expect all hruids
+  assert_that(meta_info$dimension$length[2] == 1) # Expect only one date
+  
+  # Test unit for variable
+  assert_that(meta_info$attribute$value[[var_unit_i]] == "mm") # Expect millimeters
+  
+  ##### Test: NetCDF hruids are in expected order and the expected data type #####
+  assert_that(is.integer(hruids))
+  # need to make hruids a vector instead of matrix w 1 dim in order to test sameness
+  assert_that(all(as.vector(hruids) == 1:n_hrus)) 
+  
+  ##### Test: NetCDF time is in expected order and expected data type #####
+  assert_that(is.integer(time))
+  assert_that(length(time) == 1) # Expect only 1 day of data 
+  assert_that(as.character(time_fixed) == test_date) # Expect that day to match the current date
+  
+  ##### Test: NetCDF actual data is formatted as expected #####
+  assert_that(is.double(data_nc))
+  assert_that(dim(data_nc) == n_hrus) 
+  
+  # General order of magnitude test
+  # Max of total storage in all of historic data for all HRUs is ~5,000 mm
+  # Considering 300 mm is about 1 ft of water
+  # An absolute max for order of magnitude check of 10,000 mm seems appropriate
+  assert_that(all(data_nc < 10000))
+  
+}

--- a/src/validate_total_storage_categorized.R
+++ b/src/validate_total_storage_categorized.R
@@ -1,0 +1,27 @@
+library(assertthat)
+
+validate_total_storage_categorized <- function(data_categorized, n_hrus = 109951) {
+  
+  ##### Test: Key columns exist in the data #####
+  
+  assert_that("hru_id_nat" %in% names(data_categorized))
+  assert_that("value" %in% names(data_categorized))
+  
+  ##### Test: All HRUs are in the data and in the right order #####
+  
+  assert_that(nrow(data_categorized) == n_hrus)
+  assert_that(all(data_categorized$hru_id_nat == 1:n_hrus))
+  
+  ##### Test: Only expected categories exist in the value column #####
+  
+  # We know that one CA HRU doesn't have historic data for quantiles (104388) and will be Undefined
+  # This is also true for 7 other HRUs that are not in the U.S.
+  problem_hruids <- c(104388, 46760, 46766, 46767, 82924, 82971, 82983, 82984)
+  data_categorized_problem_hru <- data_categorized[data_categorized$hru_id_nat %in% problem_hruids,]
+  data_categorized_good_hrus <- data_categorized[!data_categorized$hru_id_nat %in% problem_hruids,]
+  
+  assert_that(is.character(data_categorized$value))
+  assert_that(all(data_categorized_problem_hru$value == "Undefined"))
+  assert_that(!"Undefined" %in% unique(data_categorized_good_hrus$value))
+  
+}


### PR DESCRIPTION
This creates two new functions to test assertions related to data coming in to the `process_model_output` step and data coming out of it. It will stop executing the code if any assertion fails, but only when the code is run by using `source()`. 

@wdwatkins do you know if kicking off this script the way we do now with Jenkins is similar to `source()`? https://github.com/usgs-makerspace/wbeep-processing/blob/master/jenkins/model_output_processing_Jenkinsfile#L60 The problem is that if the code is just run (so on my computer, CTRL + A then CTRL + Enter) if the assertions fail, it will print an error but continue anyways. However, when the code in the file is run by using `source()`, if the assertions fail then the code will actually stop.

This is part of https://github.com/usgs-makerspace/makerspace-sandbox/issues/217 and https://github.com/usgs-makerspace/makerspace-sandbox/issues/218. I'd like to still work on code for validating the historic inputs/outputs during quantile processing.