### PR TITLE
Validation test updates

### DIFF
--- a/jenkins/model_output_processing_Jenkinsfile
+++ b/jenkins/model_output_processing_Jenkinsfile
@@ -9,6 +9,7 @@ pipeline {
                      type: 'PT_BRANCH_TAG',
                      defaultValue: 'master'
         choice(choices: ['test', 'qa', 'beta', 'prod'], description: 'Tier to deploy tiles to', name: 'TIER')
+        choice(choices: ['yes', 'no'], description: 'Run validation script or not', name: 'VALIDATE_DATA')
   }
   stages {
     stage('Clean Workspace') {
@@ -56,7 +57,7 @@ pipeline {
           PATTERN="*.nc"
           FILES=($PATTERN)
           DATE="${FILES:0:10}"
-          Rscript src/process_model_output.R "${DATE}"
+          Rscript src/process_model_output.R "${DATE}" "${params.VALIDATE_DATA}"
           '''
       }
     }

--- a/jenkins/model_output_processing_Jenkinsfile
+++ b/jenkins/model_output_processing_Jenkinsfile
@@ -110,7 +110,7 @@ pipeline {
             if(($FILE_NCHAR>10))
             then
               mail to: 'lplatt@usgs.gov',
-                   subject: "Suspicious data: this build",
+                   subject: "Suspicious data: ${currentBuild.fullDisplayName}",
                    body: "Pipeline finished, but had suspicious data -- ${FILE_TXT}"
             else
               echo "Data passed validation checks."

--- a/jenkins/model_output_processing_Jenkinsfile
+++ b/jenkins/model_output_processing_Jenkinsfile
@@ -104,5 +104,17 @@ pipeline {
             subject: "Changes: ${currentBuild.fullDisplayName}",
             body: "Pipeline detected changes ${env.BUILD_URL}"
         }
+        always {
+            FILE_TXT=$(cat order_of_magnitude_test.txt)
+            FILE_NCHAR=${#FILE_TXT}
+            if(($FILE_NCHAR>10))
+            then
+              mail to: 'lplatt@usgs.gov',
+                   subject: "Suspicious data: this build",
+                   body: "Pipeline finished, but had suspicious data -- ${FILE_TXT}"
+            else
+              echo "Data passed validation checks."
+            fi
+        }
     }  
 }

--- a/src/combine_hru_quantiles.R
+++ b/src/combine_hru_quantiles.R
@@ -1,42 +1,18 @@
 # Combine the resulting files from the parallel tasks in
 # process_quantiles_by_hru.R into one file and push to S3.
-# library(dplyr)
-# library(tidyr)
-# library(pryr)
+
 library(data.table)
-# ptm <- proc.time()
+
 files_to_combine <- list.files(path = "grouped_quantiles", 
                                pattern = "total_storage_quantiles",
                                full.names = TRUE)
+
 #gets daily data
 message("Read in each HRU group of quantiles file to a list")
 file_contents_list <- lapply(files_to_combine, feather::read_feather)
-# print(proc.time() - ptm)
-# ptm <- proc.time()
-# print(pryr::object_size(file_contents_list))
-# #check order of all  DOY columns by doing a logical compare
-# #could throw in an arrange here 
-# sample <- file_contents_list[[1]]$DOY
-# checks <- sapply(X = file_contents_list, 
-#                  FUN = function(x, sample) {all(x$DOY == sample)},
-#                  sample = sample)
-# print(proc.time() - ptm)
-# ptm <- proc.time()
-# stopifnot(all(checks))
 
 message("Turn each HRU group of quantiles from list into single dataset")
-combined_data <- do.call("rbind", file_contents_list)# %>%  
-#   select(DOY, matches('^[0-9]*$')) %>% 
-#   pivot_longer(cols = -DOY, names_to = "hruid",
-#                values_to = "total_storage_quantiles")
-# print(pryr::object_size(combined_data))
-# print(proc.time() - ptm)
-
-#NOTE: data.table package can modify objects in place!
-#that's why there is no explicit assignments here
-# setDT(combined_data)
-# combined_data[, c("0%", "10%", "25%", "75%", "90%", "100%") := transpose(total_storage_quantiles)]
-# combined_data[,total_storage_quantiles := NULL]
+combined_data <- do.call("rbind", file_contents_list)# 
 
 # Add -inf and +inf here since it will be the same for all 
 message("Fix quantiles to add 0% and 100%")

--- a/src/combine_hru_quantiles.R
+++ b/src/combine_hru_quantiles.R
@@ -13,7 +13,7 @@ message("Read in each HRU group of quantiles file to a list")
 file_contents_list <- lapply(files_to_combine, feather::read_feather)
 
 message("Turn each HRU group of quantiles from list into single dataset")
-combined_data <- do.call("rbind", file_contents_list)# 
+combined_data <- do.call("rbind", file_contents_list) 
 
 # Add -inf and +inf here since it will be the same for all 
 message("Fix quantiles to add 0% and 100%")

--- a/src/combine_hru_quantiles.R
+++ b/src/combine_hru_quantiles.R
@@ -2,6 +2,7 @@
 # process_quantiles_by_hru.R into one file and push to S3.
 
 library(data.table)
+source("src/validate_historic_quantile_data.R") # load code to test model data
 
 files_to_combine <- list.files(path = "grouped_quantiles", 
                                pattern = "total_storage_quantiles",
@@ -23,6 +24,11 @@ combined_data[, "100%" := Inf]
 setcolorder(combined_data, c("hruid", "DOY", "0%",
                              original_quantiles,
                              "100%"))
+
+# Validate that outgoing quantiles are as expected
+message("Started tests for validating calcalated quantiles")
+validate_historic_quantile_data(combined_data)
+message("Completed tests for validating calcalated quantiles")
 
 message("Save quantiles `as all_quantiles.rds`")
 saveRDS(combined_data, "all_quantiles.rds")

--- a/src/process_model_output.R
+++ b/src/process_model_output.R
@@ -5,6 +5,7 @@ library(dplyr)
 
 args <- commandArgs(trailingOnly=TRUE)
 today <- args[1] #today <- "2019-07-31"
+validate_data <- args[2] == "yes" # defaults to 'yes'
 
 source("src/validate_oNHM_daily_output.R") # load code to test model data
 source("src/validate_total_storage_categorized.R") # load code to test output of this categorization
@@ -28,9 +29,11 @@ var_data_list <- lapply(vars, function(var) {
   today_data_nc <- ncvar_get(nc, var, start = c(1,today_dim), count = c(-1, 1))
 
   # Run tests before returning any data
-  message(sprintf("Started tests for %s", var))
-  validate_oNHM_daily_output(var, fn, today, today_data_nc, hruids, time, time_fixed)
-  message(sprintf("Completed tests for %s", var))
+  if(validate_data) {
+    message(sprintf("Started tests for %s", var))
+    validate_oNHM_daily_output(var, fn, today, today_data_nc, hruids, time, time_fixed)
+    message(sprintf("Completed tests for %s", var))
+  }
   
   today_var_data <- data.frame(
     hruid = as.numeric(hruids),
@@ -105,8 +108,10 @@ values_categorized <- total_storage_data %>%
                                      `0%`, `10%`, `25%`, `75%`, `90%`, `100%`)) %>%
   rename(hru_id_nat = hruid)
 
-message("Started tests for validating categorized output")
-validate_total_storage_categorized(values_categorized)
-message("Completed tests for validating categorized output")
+if(validate_data) {
+  message("Started tests for validating categorized output")
+  validate_total_storage_categorized(values_categorized)
+  message("Completed tests for validating categorized output")
+}
 
 readr::write_csv(values_categorized, "model_output_categorized.csv")

--- a/src/sum_total_storage.R
+++ b/src/sum_total_storage.R
@@ -15,10 +15,10 @@ start_of_loop <- Sys.time()
 
 vars <- c(
   "soil_moist_tot",
-  #"pkwater_equiv",
+  "pkwater_equiv",
   "hru_intcpstor", 
-  #"hru_impervstor", 
-  #"gwres_stor", 
+  "hru_impervstor", 
+  "gwres_stor", 
   "dprst_stor_hru"
 )
 

--- a/src/validate_historic_driver_data.R
+++ b/src/validate_historic_driver_data.R
@@ -1,0 +1,52 @@
+library(assertthat)
+library(ncmeta)
+
+validate_historic_driver_data <- function(var, fn, data_nc, hruids, time, time_fixed, n_hrus = 109951, n_days = 12783) {
+  
+  # 12783 days is ~ 35 years
+  
+  ##### Test: NetCDF dimensions and variables are as expected #####
+  
+  # Get a bit more detailed metadata
+  meta_info <- nc_meta(fn)
+  atts_var_i <- which(meta_info$attribute$variable == var)
+  atts_units_i <- which(meta_info$attribute$name == "units")
+  var_unit_i <- atts_units_i[atts_units_i %in% atts_var_i]
+  
+  assert_that(meta_info$dimension$name[1] == "hruid")
+  assert_that(meta_info$dimension$name[2] == "time")
+  assert_that(meta_info$dimension$length[1] == n_hrus) # Expect all hruids
+  assert_that(meta_info$dimension$length[2] == n_days) # Expect a specific number of days
+  
+  # Test unit for variable
+  assert_that(meta_info$attribute$value[[var_unit_i]] == "mm") # Expect millimeters
+  
+  ##### Test: NetCDF hruids are in expected order and the expected data type #####
+  assert_that(is.integer(hruids))
+  assert_that(all(as.vector(hruids) == 1:n_hrus)) # need to make hruids a vector instead of matrix w 1 dim in order to test sameness
+  
+  ##### Test: NetCDF time is in expected order and expected data type #####
+  assert_that(is.integer(time))
+  assert_that(length(time) == n_days) # Expect a specific number of days 
+  
+  ##### Test: NetCDF actual data is formatted as expected #####
+  assert_that(is.double(data_nc))
+  assert_that(nrow(data_nc) == n_hrus) 
+  assert_that(ncol(data_nc) == n_days) 
+  
+  # General order of magnitude test
+  # Max of total storage in all of historic data for all HRUs is ~5,000 mm
+  # Considering 300 mm is about 1 ft of water
+  # An absolute max for order of magnitude check of 10,000 mm seems appropriate
+  assert_that(max(data_nc) < 10000)
+  
+}
+
+validate_historic_data_times_match <- function(date_list, vars) {
+  for(i in head(seq_along(vars), -1)) {
+    var1 <- vars[i]
+    var2 <- vars[i+1]
+    message(sprintf("Running test for times in %s == %s", var1, var2))
+    assert_that(all(date_list[[var1]] == date_list[[var2]]))
+  }
+}

--- a/src/validate_historic_driver_data.R
+++ b/src/validate_historic_driver_data.R
@@ -10,7 +10,7 @@ validate_historic_driver_data <- function(var, fn, data_nc, hruids, time, time_f
   # Get a bit more detailed metadata
   meta_info <- nc_meta(fn)
   atts_var_i <- which(meta_info$attribute$variable == var)
-  atts_units_i <- which(meta_info$attribute$name == "units")
+  atts_units_i <- which(meta_info$attribute$attribute == "units")
   var_unit_i <- atts_units_i[atts_units_i %in% atts_var_i]
   
   assert_that(meta_info$dimension$name[1] == "hruid")

--- a/src/validate_historic_driver_data.R
+++ b/src/validate_historic_driver_data.R
@@ -40,6 +40,12 @@ validate_historic_driver_data <- function(var, fn, data_nc, hruids, time, time_f
   # An absolute max for order of magnitude check of 10,000 mm seems appropriate
   assert_that(max(data_nc) < 10000)
   
+  # The validation step for order of magnitude for the daily model output has this step
+  # but it will send an email (NOT FAIL) if this condition is not met. For the purposes
+  # of calculating the historic percentiles, we will have this step fail if it is not met. 
+  # The historic percentile calculation is more hands on and people should investigate this
+  # issue immediately before proceeding.
+  
 }
 
 validate_historic_data_times_match <- function(date_list, vars) {

--- a/src/validate_historic_driver_data.R
+++ b/src/validate_historic_driver_data.R
@@ -9,9 +9,6 @@ validate_historic_driver_data <- function(var, fn, data_nc, hruids, time, time_f
   
   # Get a bit more detailed metadata
   meta_info <- nc_meta(fn)
-  atts_var_i <- which(meta_info$attribute$variable == var)
-  atts_units_i <- which(meta_info$attribute$attribute == "units")
-  var_unit_i <- atts_units_i[atts_units_i %in% atts_var_i]
   
   assert_that(meta_info$dimension$name[1] == "hruid")
   assert_that(meta_info$dimension$name[2] == "time")
@@ -19,7 +16,8 @@ validate_historic_driver_data <- function(var, fn, data_nc, hruids, time, time_f
   assert_that(meta_info$dimension$length[2] == n_days) # Expect a specific number of days
   
   # Test unit for variable
-  assert_that(meta_info$attribute$value[[var_unit_i]] == "mm") # Expect millimeters
+  units_att_list <- nc_att(fn, var, "units")[["value"]]
+  assert_that(unlist(units_att_list) == "mm") # Expect millimeters
   
   ##### Test: NetCDF hruids are in expected order and the expected data type #####
   assert_that(is.integer(hruids))

--- a/src/validate_historic_quantile_data.R
+++ b/src/validate_historic_quantile_data.R
@@ -1,0 +1,47 @@
+library(assertthat)
+
+### DELETE WHEN DONE ###
+combined_data <- readRDS("all_quantiles.rds")
+quantile_data <- combined_data
+### /////////////// ###
+
+validate_historic_quantile_data <- function(quantile_data, n_hrus = 109951, n_days = 365) {
+  
+  # n_days at 365 until leap years are dealt with
+  
+  ##### Test: dimensions are as expected #####
+  percentile_cols <- names(quantile_data)[grepl("%", names(quantile_data))]
+  assert_that(nrow(quantile_data) == n_hrus*n_days) # There is one row of data per HRU per day of year
+  assert_that("hruid" %in% names(quantile_data)) # must have hruid col
+  assert_that("DOY" %in% names(quantile_data)) # must have DOY col
+  assert_that(all(names(quantile_data) %in% c("hruid", "DOY", percentile_cols))) # Test that there are no extra columns
+  
+  ##### Test: percentile columns are within appropriate bounds #####
+  percentile_vals <- as.numeric(gsub("%", "", percentile_cols))
+  assert_that(all(percentile_vals >= 0 & percentile_vals <= 100))
+  
+  ##### Test: boundaries of categories #####
+  assert_that(all(quantile_data[["0%"]] == -Inf))
+  assert_that(all(quantile_data[["100%"]] == Inf))
+  
+  ##### Test: HRUs with missing quantile data #####
+  
+  # We know that one CA HRU doesn't have historic data for quantiles (104388) and will be Undefined
+  # This is also true for 7 other HRUs that are not in the U.S.
+  problem_hruids <- c(104388, 46760, 46766, 46767, 82924, 82971, 82983, 82984)
+  quantiles_problem_hru <- unlist(quantile_data[quantile_data$hruid %in% problem_hruids,], use.names=FALSE)
+  quantiles_good_hrus <- quantile_data[!quantile_data$hruid %in% problem_hruids,]
+
+  ####### THIS IS NOT AS EXPECTED  ####### 
+  assert_that(any(is.na(quantiles_problem_hru)))
+  assert_that(!"Undefined" %in% unique(data_categorized_good_hrus$value))
+  
+  # General order of magnitude test
+  # Max of total storage in all of historic total storage data for all HRUs is ~8,000 mm
+  # Considering 300 mm is about 1 ft of water (diff between historic max and assumed max is ~ 6.5 ft of water)
+  # An absolute max for order of magnitude check of 10,000 mm seems appropriate
+  real_cols <- names(quantile_data)[!names(quantile_data) %in% c("0%", "100%")]
+  just_quantile_data <- as.matrix(quantile_data[,grep("%", real_cols)])
+  assert_that(max(just_quantile_data) < 10000) 
+  
+}

--- a/src/validate_historic_quantile_data.R
+++ b/src/validate_historic_quantile_data.R
@@ -1,10 +1,5 @@
 library(assertthat)
 
-### DELETE WHEN DONE ###
-combined_data <- readRDS("all_quantiles.rds")
-quantile_data <- combined_data
-### /////////////// ###
-
 validate_historic_quantile_data <- function(quantile_data, n_hrus = 109951, n_days = 365) {
   
   # n_days at 365 until leap years are dealt with
@@ -29,19 +24,18 @@ validate_historic_quantile_data <- function(quantile_data, n_hrus = 109951, n_da
   # We know that one CA HRU doesn't have historic data for quantiles (104388) and will be Undefined
   # This is also true for 7 other HRUs that are not in the U.S.
   problem_hruids <- c(104388, 46760, 46766, 46767, 82924, 82971, 82983, 82984)
-  quantiles_problem_hru <- unlist(quantile_data[quantile_data$hruid %in% problem_hruids,], use.names=FALSE)
-  quantiles_good_hrus <- quantile_data[!quantile_data$hruid %in% problem_hruids,]
-
-  ####### THIS IS NOT AS EXPECTED  ####### 
-  assert_that(any(is.na(quantiles_problem_hru)))
-  assert_that(!"Undefined" %in% unique(data_categorized_good_hrus$value))
+  real_cols <- percentile_cols[!percentile_cols %in% c("0%", "100%")]
+  quantiles_problem_hru <- unlist(quantile_data[quantile_data$hruid %in% problem_hruids, real_cols], use.names=F)
+  quantiles_good_hrus <- unlist(quantile_data[!quantile_data$hruid %in% problem_hruids, real_cols], use.names=F)
+  assert_that(all(quantiles_problem_hru == 0)) # Every quantile will be 0 for these bad HRUs
+  assert_that(any(quantiles_good_hrus > 0)) # There will be some that are greater than zero
   
-  # General order of magnitude test
+  ##### Test: General order of magnitude #####
+  
   # Max of total storage in all of historic total storage data for all HRUs is ~8,000 mm
   # Considering 300 mm is about 1 ft of water (diff between historic max and assumed max is ~ 6.5 ft of water)
   # An absolute max for order of magnitude check of 10,000 mm seems appropriate
-  real_cols <- names(quantile_data)[!names(quantile_data) %in% c("0%", "100%")]
-  just_quantile_data <- as.matrix(quantile_data[,grep("%", real_cols)])
+  just_quantile_data <- as.matrix(quantile_data[,real_cols])
   assert_that(max(just_quantile_data) < 10000) 
   
 }

--- a/src/validate_oNHM_daily_output.R
+++ b/src/validate_oNHM_daily_output.R
@@ -34,7 +34,7 @@ validate_oNHM_daily_output <- function(var, fn, test_date, data_nc, hruids, time
   assert_that(dim(data_nc) == n_hrus) 
   
   # General order of magnitude test
-  # Max of total storage in all of historic data for all HRUs is ~5,000 mm
+  # Max of total storage in all of historic data for all HRUs is ~8,000 mm
   # Considering 300 mm is about 1 ft of water
   # An absolute max for order of magnitude check of 10,000 mm seems appropriate
   data_is_good <- all(data_nc < 10000)

--- a/src/validate_oNHM_daily_output.R
+++ b/src/validate_oNHM_daily_output.R
@@ -37,6 +37,16 @@ validate_oNHM_daily_output <- function(var, fn, test_date, data_nc, hruids, time
   # Max of total storage in all of historic data for all HRUs is ~5,000 mm
   # Considering 300 mm is about 1 ft of water
   # An absolute max for order of magnitude check of 10,000 mm seems appropriate
-  assert_that(all(data_nc < 10000))
+  data_is_good <- all(data_nc < 10000)
+  if(data_is_good) {
+    # Write out a text file that won't have Jenkins send an email.
+    writeLines("NULL", "order_of_magnitude_test.txt")
+  } else {
+    # Write out a text file that will eventually cause the Jenkins file to send an email
+    bad_data_hruids <- hruids[which(data_nc >= 10000)]
+    writeLines(text = sprintf("The following HRUIDs have data >= 10,000: %s", 
+                              paste(bad_data_hruids, collapse = ", ")), 
+               con = "order_of_magnitude_test.txt")
+  }
   
 }

--- a/src/validate_oNHM_daily_output.R
+++ b/src/validate_oNHM_daily_output.R
@@ -7,9 +7,6 @@ validate_oNHM_daily_output <- function(var, fn, test_date, data_nc, hruids, time
   
   # Get a bit more detailed metadata
   meta_info <- nc_meta(fn)
-  atts_var_i <- which(meta_info$attribute$variable == var)
-  atts_units_i <- which(meta_info$attribute$attribute == "units")
-  var_unit_i <- atts_units_i[atts_units_i %in% atts_var_i]
   
   assert_that(meta_info$dimension$name[1] == "hruid")
   assert_that(meta_info$dimension$name[2] == "time")
@@ -17,7 +14,8 @@ validate_oNHM_daily_output <- function(var, fn, test_date, data_nc, hruids, time
   assert_that(meta_info$dimension$length[2] == 1) # Expect only one date
   
   # Test unit for variable
-  assert_that(meta_info$attribute$value[[var_unit_i]] == "mm") # Expect millimeters
+  units_att_list <- nc_att(fn, var, "units")[["value"]]
+  assert_that(unlist(units_att_list) == "mm") # Expect millimeters
   
   ##### Test: NetCDF hruids are in expected order and the expected data type #####
   assert_that(is.integer(hruids))


### PR DESCRIPTION
Major changes from the last PR for validation (#93, #96): 

1. Historic data validation has been added. This checks historic data inputs to the quantile calculation and outputs.
2. Order of magnitude test for daily model output does not fail, but sends an email saying which HRUs did not pass this test.
3. Option to override validation check for the daily model runs by changing the Jenkins parameter `VALIDATE_DATA` to `'no'` (default: `'yes'`) in the `process_model_output` job on WMA Jenkins. This means that if your data is bad, but you still want to see it on test, you can manually build and skip the validation. Did not implement this for the historic data validation since it is more manual anyways and you should either investigate the failure or could easily comment out the test that is failing. 

Tried my hand at shell scripting a solution for sending an email using a custom condition (when there is data that is > 10,000). I gave up trying to figure out how to have R send an email and had the R validation script write out a text file. Then the Jenkinsfile checks that file and sends an email if it has more than just the text `NULL` in it. To develop this solution, I referenced the general Pipeline syntax for `post` from [here](https://jenkins.io/doc/book/pipeline/syntax/#post) and looked at an example of how the email was formatted [here](https://jenkins.io/doc/pipeline/tour/post/#email).

The rest of https://github.com/usgs-makerspace/makerspace-sandbox/issues/218 & https://github.com/usgs-makerspace/makerspace-sandbox/issues/217 🤞 