### PR TITLE
new validation steps: jenkinsfile syntax is still missing something ...

### DIFF
--- a/jenkins/model_output_processing_Jenkinsfile
+++ b/jenkins/model_output_processing_Jenkinsfile
@@ -105,6 +105,7 @@ pipeline {
             body: "Pipeline detected changes ${env.BUILD_URL}"
         }
         always {
+          steps {
             if ((new File(order_of_magnitude_test.txt).length()) > 10) {
 	            mail to: 'mhines@usgs.gov, wwatkins@usgs.gov, lplatt@usgs.gov',
 		          subject: "Suspicious data: ${currentBuild.fullDisplayName}",
@@ -113,6 +114,7 @@ pipeline {
             } else {
             	println "Data passed validation checks."
             }
+          }
         }
     }  
 }


### PR DESCRIPTION
Tried to build the Jenkins job and got this error:

```
WorkflowScript: 108: Expected a step @ line 108, column 13.
               if ((new File(order_of_magnitude_test.txt).length()) > 10) {
               ^
```

Read the pipeline syntax documentation again. Under [post](https://jenkins.io/doc/book/pipeline/syntax/#post), it states that `Post-condition blocks contain steps the same as the steps section.`. In the [steps section](https://jenkins.io/doc/book/pipeline/syntax/#steps), it talks about using `steps{}` to wrap the code.