### PR TITLE
new validation steps: another syntax attempt for jenkinsfile

### DIFF
--- a/jenkins/model_output_processing_Jenkinsfile
+++ b/jenkins/model_output_processing_Jenkinsfile
@@ -106,13 +106,16 @@ pipeline {
         }
         always {
           steps {
-            if ((new File(order_of_magnitude_test.txt).length()) > 10) {
-	            mail to: 'mhines@usgs.gov, wwatkins@usgs.gov, lplatt@usgs.gov',
-		          subject: "Suspicious data: ${currentBuild.fullDisplayName}",
-		          body: "Pipeline finished, but had suspicious data -- see file attached."
-		          attachmentsPattern: 'order_of_magnitude_test.txt'
-            } else {
-            	println "Data passed validation checks."
+            script {
+              if ((new File(order_of_magnitude_test.txt).length()) > 10) {
+  	            mail to: 'mhines@usgs.gov, wwatkins@usgs.gov, lplatt@usgs.gov',
+  		               subject: "Suspicious data: ${currentBuild.fullDisplayName}",
+  		               body: "Pipeline finished, but had suspicious data -- see file attached."
+  		          attachmentsPattern: 'order_of_magnitude_test.txt'
+  		          echo "Data failed validation checks. An email was sent."
+              } else {
+              	echo "Data passed validation checks."
+              }
             }
           }
         }


### PR DESCRIPTION
The jenkins job failed with the same message, only on the next line. Testing with `script{}` and changed prints to `echo` after reading some more about syntax [here](https://jenkins.io/doc/book/pipeline/syntax/#script): `The script step takes a block of Scripted Pipeline and executes that in the Declarative Pipeline.`.

Will try this, but also wondering if `steps{}` is not unnecessary. Will see.