### PR TITLE
new validation steps: changing post step from always to cleanup

### DIFF
--- a/jenkins/model_output_processing_Jenkinsfile
+++ b/jenkins/model_output_processing_Jenkinsfile
@@ -104,7 +104,7 @@ pipeline {
             subject: "Changes: ${currentBuild.fullDisplayName}",
             body: "Pipeline detected changes ${env.BUILD_URL}"
         }
-        always {
+        cleanup {
           script {
             File file = new File("order_of_magnitude_test.txt")
             if (file.exists()) {


### PR DESCRIPTION
It keeps running before the order_of_magnitude_test.txt file is created, so it isn't really doing a "post" step. Wondering if changing to "cleanup" will mean it definitely waits all the way until the end. See https://jenkins.io/doc/book/pipeline/syntax/#post for a description.