### PR TITLE
new validation steps: debugging jenkins job

### DIFF
--- a/jenkins/model_output_processing_Jenkinsfile
+++ b/jenkins/model_output_processing_Jenkinsfile
@@ -106,6 +106,10 @@ pipeline {
         }
         cleanup {
           script {
+            dh = new File('.')
+            dh.eachFile {
+                println(it)
+            }
             File file = new File("order_of_magnitude_test.txt")
             if (file.exists()) {
               if ((file.length()) > 200) {


### PR DESCRIPTION
Printing out directory during cleanup script to see if the reason it keeps saying "Data validation skipped." is because of a filepath thing since the "order_of_magnitude_test.txt" file exists in the Workspace.