### PR TITLE
new validation steps: look for file in a different dir

### DIFF
--- a/jenkins/model_output_processing_Jenkinsfile
+++ b/jenkins/model_output_processing_Jenkinsfile
@@ -116,7 +116,7 @@ pipeline {
   	            mail to: 'mhines@usgs.gov, wwatkins@usgs.gov, lplatt@usgs.gov',
   		               subject: "Suspicious data: ${currentBuild.fullDisplayName}",
   		               body: "Pipeline finished, but had suspicious data -- see file attached."
-  		          attachmentsPattern: 'order_of_magnitude_test.txt'
+  		          attachmentsPattern: '../order_of_magnitude_test.txt'
   		          println "Data failed validation checks. An email was sent."
               } else {
               	println "Data passed validation checks."

--- a/jenkins/model_output_processing_Jenkinsfile
+++ b/jenkins/model_output_processing_Jenkinsfile
@@ -110,7 +110,7 @@ pipeline {
             dh.eachFile {
                 println(it)
             }
-            File file = new File("order_of_magnitude_test.txt")
+            File file = new File("../order_of_magnitude_test.txt")
             if (file.exists()) {
               if ((file.length()) > 200) {
   	            mail to: 'mhines@usgs.gov, wwatkins@usgs.gov, lplatt@usgs.gov',


### PR DESCRIPTION
Had the last run print the current dir while it ran the cleanup steps in the jenkins job and it seems that the script may be running inside  `./dev`. So, if we change the filepath to look up one, then it may work!