### PR TITLE
Only create zoom levels 0-6 for rivers

### DIFF
--- a/jenkins/create_rivers_basemap
+++ b/jenkins/create_rivers_basemap
@@ -41,7 +41,7 @@ pipeline {
       }
       steps {
         sh "mkdir ${WORKSPACE}/nhd_order_grouped"
-        sh 'tippecanoe -zg --simplify-only-low-zooms --no-simplification-of-shared-nodes --drop-fraction-as-needed --no-feature-limit --simplification=5 --output-to-directory nhd_order_grouped most_detail.geojson medium_detail.geojson least_detail.geojson'
+        sh 'tippecanoe -z6 -Z0 --simplify-only-low-zooms --no-simplification-of-shared-nodes --drop-fraction-as-needed --no-feature-limit --simplification=5 --output-to-directory nhd_order_grouped most_detail.geojson medium_detail.geojson least_detail.geojson'
       }
     }
     stage('push to S3') {


### PR DESCRIPTION
Currently they appear kind of funky with our new zoom restrictions, try recreating them at the known needed zoom levels to see if they appear more useful.