### PR TITLE
new validation steps: move from post into a stage

### DIFF
--- a/jenkins/model_output_processing_Jenkinsfile
+++ b/jenkins/model_output_processing_Jenkinsfile
@@ -82,6 +82,28 @@ pipeline {
               string(name: 'BRANCH_TAG', value: "${params.BRANCH_TAG}")]
       }
     }
+    stage('Execute data validation steps') {
+      steps {
+        dh = new File('.')
+        dh.eachFile {
+            println(it)
+        }
+        File file = new File("order_of_magnitude_test.txt")
+        if (file.exists()) {
+          if ((file.length()) > 200) {
+            mail to: 'mhines@usgs.gov, wwatkins@usgs.gov, lplatt@usgs.gov',
+                 subject: "Suspicious data: ${currentBuild.fullDisplayName}",
+                 body: "Pipeline finished, but had suspicious data -- see file attached."
+            attachmentsPattern: 'order_of_magnitude_test.txt'
+            println "Data failed validation checks. An email was sent."
+          } else {
+          	println "Data passed validation checks."
+          }
+        } else {
+          println "Data validation skipped."
+        }
+      }
+    }
   }
     post {
         success {
@@ -103,28 +125,6 @@ pipeline {
             mail to: 'mhines@usgs.gov, wwatkins@usgs.gov',
             subject: "Changes: ${currentBuild.fullDisplayName}",
             body: "Pipeline detected changes ${env.BUILD_URL}"
-        }
-        cleanup {
-          script {
-            dh = new File('.')
-            dh.eachFile {
-                println(it)
-            }
-            File file = new File("../order_of_magnitude_test.txt")
-            if (file.exists()) {
-              if ((file.length()) > 200) {
-  	            mail to: 'mhines@usgs.gov, wwatkins@usgs.gov, lplatt@usgs.gov',
-  		               subject: "Suspicious data: ${currentBuild.fullDisplayName}",
-  		               body: "Pipeline finished, but had suspicious data -- see file attached."
-  		          attachmentsPattern: '../order_of_magnitude_test.txt'
-  		          println "Data failed validation checks. An email was sent."
-              } else {
-              	println "Data passed validation checks."
-              }
-            } else {
-              println "Data validation skipped."
-            }
-          }
         }
     }  
 }


### PR DESCRIPTION
There seem to be some file path issues. David suggests moving it to a "stage" block so that it would be running in the same workspace as the files it creates/finds just fine before (e.g. `all_quantiles.rds`).