### PR TITLE
add estimated-availability folder to final destination s3 location

### DIFF
--- a/jenkins/tippecanoe_tile_join_Jenkinsfile
+++ b/jenkins/tippecanoe_tile_join_Jenkinsfile
@@ -54,8 +54,8 @@ pipeline {
         script {
           targetDomain = "s3://wbeep-${TIER}-website"
         }
-        sh "aws s3 sync tilesFinal ${targetDomain}/tiles --content-encoding gzip --content-type application/x-protobuf"
-        sh "aws s3 cp date.txt ${targetDomain}/date/date.txt --content-encoding text/html --content-type text/plain"
+        sh "aws s3 sync tilesFinal ${targetDomain}/estimated-availability/tiles --content-encoding gzip --content-type application/x-protobuf"
+        sh "aws s3 cp date.txt ${targetDomain}/estimated-availability/date/date.txt --content-encoding text/html --content-type text/plain"
       }
     }
   }


### PR DESCRIPTION
this should not be merged until similar modifications are made on the wbeep-viz repo and any necessary jenkins jobs to make sure we don't 'lose' the path to the live tiles 