### PR TITLE
water temp: segments - handle z dimension in new geospatial fabric

### DIFF
--- a/src/process_segsAllConus.R
+++ b/src/process_segsAllConus.R
@@ -4,4 +4,6 @@ library(lwgeom)
 proj_string <- 4326
 segsAllConus <- st_read("cache/segsAllConus.shp")
 segsAllConus4326 <- st_transform(segsAllConus,proj_string)
+#remove the z dimension from the shapefile data otherwise writing out the file fails
+segsAllConus4326 <- st_zm(segsAllConus4326, drop=T, what='ZM')
 write_sf(segsAllConus4326,'segsAllConus4326.shp')


### PR DESCRIPTION
running this locally I ran into a difference in the shapefile\layer for segments, in that it has a z dimension in it versus the previous version from steve markstrom that we worked with did not. 

this modification drops that z dimension if it exists since we do not use it, and because it causes an error if we don't remove that before writing out the file. i found the suggestion here: https://community.rstudio.com/t/issues-with-writing-a-dataframe-to-a-shapefile/42449/7

if the shapefile in the future for some reason doesn't have a z dimension, running this command against it has no ill effects.