### PR TITLE
taking daily nc and prepping as CSV for tile join

### DIFF
--- a/src/process_model_output_temp.R
+++ b/src/process_model_output_temp.R
@@ -1,0 +1,19 @@
+# Code for stream temperature daily build
+
+library(ncdf4)
+library(dplyr)
+library(readr)
+
+args <- commandArgs(trailingOnly=TRUE)
+today <- args[1]
+fn <- sprintf("%s_seg_tave_water.nc", today)
+nc <- nc_open(fn)
+
+tibble(Date = today, 
+       nhm_seg = ncvar_get(nc, varid = "segid"),
+       temp = ncvar_get(nc, varid = "seg_tave_water")) %>% 
+  # PRMS documentation states:
+  #   -99.9 means that the segment never has any flow (determined up in init).
+  #   -98.9 means that this a segment that could have flow, but doesn't
+  filter(!temp %in% c(-99.9, -98.9)) %>% 
+  write_csv(sprintf("stream_temp_%s.csv", format(as.Date(today), "%Y_%m_%d")))


### PR DESCRIPTION
@mhines-usgs here is the code that I think should do the trick. I just tested it out by downloading the nc files that are in that S3 bucket right now; it was uploaded yesterday but is for Feb 7, 2020. Unfortunately, the `nc` file values for temperature were crazy. When I looked at the summary of values from the CSV that was up there, it looked reasonable. Hoping that is just something that gets fixed when they put the most recent data up.

```
> summary(temp_nc)
     Min.   1st Qu.    Median      Mean   3rd Qu.      Max. 
      0.0      54.7     265.8    6529.7    1395.7 2508745.5 
> summary(temp_csv)
   Min. 1st Qu.  Median    Mean 3rd Qu.    Max.    NA's 
  0.000   5.764   9.550  10.149  14.089  24.484     107 
``` 

