### PR TITLE
water storage: changes based on new gdb

### DIFF
--- a/jenkins/hru_R_Jenkinsfile
+++ b/jenkins/hru_R_Jenkinsfile
@@ -26,7 +26,7 @@ pipeline {
                           submoduleCfg: [],
                           userRemoteConfigs: [[url: 'https://github.com/usgs-makerspace/wbeep-processing']]
                         ])
-        sh 'aws s3 cp --recursive s3://prod-owi-resources/resources/Application/wbeep/${TIER}/hru_shape/GF_nat_reg.gdb cache/GF_nat_reg.gdb'
+        sh 'aws s3 cp --recursive s3://prod-owi-resources/resources/Application/wbeep/${TIER}/hru_shape/GFv1.1.gdb cache/GFv1.1.gdb'
       }
     }
     stage('convert shapefile to geojson') {

--- a/src/process_hru_shapes.R
+++ b/src/process_hru_shapes.R
@@ -3,8 +3,8 @@ library(lwgeom)
 #proj_string <- '+proj=aea +lat_1=29.5 +lat_2=45.5 +lat_0=37.5 +lon_0=-96 +x_0=0 +y_0=0 +ellps=GRS80 +datum=NAD83 +units=m'
 proj_string <- 4326
 
-gfdb <- "cache/GF_nat_reg.gdb"
-hru_reduced <- read_sf(gfdb, "nhru")  %>% 
+gfdb <- "cache/GFv1.1.gdb"
+hru_reduced <- read_sf(gfdb, "nhru_v1_1")  %>% 
   dplyr::select(Shape, hru_id_nat) %>% 
   st_transform(crs = proj_string) %>% 
   dplyr::mutate(hru_id_2 = hru_id_nat) #need ID in two places in final output


### PR DESCRIPTION
based on new geodatabase names, update

when I ran this locally, I'm seeing

> write_sf(hru_reduced, 'hru_reduced_valid.shp')
Warning message:
In CPL_write_ogr(obj, dsn, layer, driver, as.character(dataset_options),  :
  GDAL Message 1: 2GB file size limit reached for hru_reduced_valid.shp. Going on, but might cause compatibility issues with third party software

not entirely sure if this is an issue since it's just a warning, but but making a note of it in case we see any funky things with the new tiles/join/etc.