### PR TITLE
use hyphens instead of underscores in date

### DIFF
--- a/src/process_model_output_temp.R
+++ b/src/process_model_output_temp.R
@@ -16,4 +16,4 @@ tibble(Date = today,
   #   -99.9 means that the segment never has any flow (determined up in init).
   #   -98.9 means that this a segment that could have flow, but doesn't
   filter(!temp %in% c(-99.9, -98.9)) %>% 
-  write_csv(sprintf("stream_temp_%s.csv", format(as.Date(today), "%Y_%m_%d")))
+  write_csv(sprintf("stream_temp_%s.csv", format(as.Date(today), "%Y-%m-%d")))


### PR DESCRIPTION
the pipeline expects the date in the file name to use hyphens otherwise it says it can't find the file, so updating the output to use hyphens to match. 