### PR TITLE
adjust urls in email notifications so beta and prod work

### DIFF
--- a/jenkins/model_output_processing_Jenkinsfile
+++ b/jenkins/model_output_processing_Jenkinsfile
@@ -90,6 +90,18 @@ pipeline {
       always {
           script {
             env.DATE = sh(script: 'cat date.txt', , returnStdout: true).trim()
+            if (env.TIER == 'beta') {
+                        targetDomain = "https://labs-beta.waterdata.usgs.gov"
+            }
+            if (env.TIER == 'prod') {
+                        targetDomain = "https://labs.waterdata.usgs.gov"
+            }
+            if (env.TIER == 'test' ) {
+                        targetDomain = "https://wbeep-test-website.s3-us-west-2.amazonaws.com"
+            }
+            if (env.TIER == 'qa') {
+                        targetDomain = "https://wbeep-qa-website.s3-us-west-2.amazonaws.com"
+            }
           }
       }      
         success {
@@ -97,14 +109,14 @@ pipeline {
             subject: "${TIER} Success: ${currentBuild.fullDisplayName}",
             body: "Pipeline finished successfully \'${env.BUILD_URL}\'\n\n" +
             "Test result summary:\n" +
-            "https://wbeep-${TIER}-website.s3-us-west-2.amazonaws.com/estimated-availability/date/test_results/order_of_magnitude_test_${env.DATE}.html"
+            "${targetDomain}/estimated-availability/date/test_results/order_of_magnitude_test_${env.DATE}.html"
         }
         unstable {        
             mail to: 'gs-w_onhm@usgs.gov',
             subject: "${TIER} Unstable: ${currentBuild.fullDisplayName}",
             body: "Pipeline is unstable \'${env.BUILD_URL}\'\n\n" +
             "Test result summary:\n" +
-            "https://wbeep-${TIER}-website.s3-us-west-2.amazonaws.com/estimated-availability/date/test_results/order_of_magnitude_test_${env.DATE}.html" 
+            "${targetDomain}/estimated-availability/date/test_results/order_of_magnitude_test_${env.DATE}.html" 
        }
         failure {       
             mail to: 'gs-w_onhm@usgs.gov',
@@ -116,7 +128,7 @@ pipeline {
             subject: "${TIER} Changes: ${currentBuild.fullDisplayName}",
             body: "Pipeline changed \'${env.BUILD_URL}\'\n\n" +
             "Test result summary:\n" +
-            "https://wbeep-${TIER}-website.s3-us-west-2.amazonaws.com/estimated-availability/date/test_results/order_of_magnitude_test_${env.DATE}.html"
+            "${targetDomain}/estimated-availability/date/test_results/order_of_magnitude_test_${env.DATE}.html"
        }
     }  
 }


### PR DESCRIPTION
currently test and qa are internal only, and beta and prod are public, so we should use those urls. beta should work after this runs again and notifies tonight with new urls, and prod will work when we remove the redirect on that current url.